### PR TITLE
feat: hide cursor whilst menu is open

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Plug {'windwp/lsp-fastaction.nvim'}
 ```lua
 --- sample for dart with flutter
 fastaction.setup({
+    hide_cursor = true,
     action_data = {
-      --- action for filteype dart
+      --- action for filetype dart
         ['dart'] = {
             -- pattern is a lua regex with lower case
             { pattern = 'import library', key = 'i', order = 1 },

--- a/lua/lsp-fastaction/init.lua
+++ b/lua/lsp-fastaction/init.lua
@@ -9,6 +9,7 @@ local namespace = api.nvim_create_namespace('windmenu')
 
 local defaults_config = {
     action_data = {},
+    hide_cursor = true,
     highlight = {
         window = 'NormalFloat',
         divider = 'FloatBorder',
@@ -102,7 +103,9 @@ local show_menu = function(responses)
     api.nvim_buf_add_highlight(bufnr, namespace, state.config.highlight.title, 0, 0, -1)
     api.nvim_buf_add_highlight(bufnr, namespace, state.config.highlight.divider, 1, 0, -1)
 
-    window.hide_cursor(bufnr)
+    if state.config.hide_cursor then
+        window.hide_cursor(bufnr)
+    end
 
     for _, action in pairs(action_tbl) do
         vim.api.nvim_buf_set_keymap(

--- a/lua/lsp-fastaction/init.lua
+++ b/lua/lsp-fastaction/init.lua
@@ -102,6 +102,8 @@ local show_menu = function(responses)
     api.nvim_buf_add_highlight(bufnr, namespace, state.config.highlight.title, 0, 0, -1)
     api.nvim_buf_add_highlight(bufnr, namespace, state.config.highlight.divider, 1, 0, -1)
 
+    window.hide_cursor(bufnr)
+
     for _, action in pairs(action_tbl) do
         vim.api.nvim_buf_set_keymap(
             bufnr,

--- a/lua/lsp-fastaction/window.lua
+++ b/lua/lsp-fastaction/window.lua
@@ -213,6 +213,21 @@ function M.popup_window(contents, filetype, opts)
     return content_buf, content_win
 end
 
+local cursor_hl_grp = 'FastActionHiddenCursor'
+
+local guicursor = vim.o.guicursor
+-- Hide cursor whilst menu is open
+function M.hide_cursor(bufnr)
+    if vim.o.termguicolors and vim.o.guicursor ~= '' then
+        local fmt = string.format
+        if vim.fn.hlexists(cursor_hl_grp) == 0 then
+            vim.cmd(fmt("highlight %s gui=reverse blend=100", cursor_hl_grp))
+        end
+        vim.o.guicursor = fmt('a:%s', cursor_hl_grp)
+        vim.cmd(fmt("autocmd! WinClosed,BufWipeout <buffer=%d> set guicursor=%s", bufnr, guicursor))
+    end
+end
+
 --  get decoration column with (signs + folding + number)
 function M.window_decoration_columns()
     local function starts_with(str, start)

--- a/lua/lsp-fastaction/window.lua
+++ b/lua/lsp-fastaction/window.lua
@@ -223,8 +223,8 @@ function M.hide_cursor(bufnr)
         if vim.fn.hlexists(cursor_hl_grp) == 0 then
             vim.cmd(fmt("highlight %s gui=reverse blend=100", cursor_hl_grp))
         end
-        vim.o.guicursor = fmt('a:%s', cursor_hl_grp)
-        vim.cmd(fmt("autocmd! WinClosed,BufWipeout <buffer=%d> set guicursor=%s", bufnr, guicursor))
+        vim.o.guicursor = fmt('a:%s/lCursor', cursor_hl_grp)
+        vim.cmd(fmt("autocmd! BufLeave,WinLeave,CmdwinEnter,CmdlineEnter <buffer=%d> set guicursor=%s", bufnr, guicursor))
     end
 end
 


### PR DESCRIPTION
@windwp this is the change I discussed re. hiding the cursor.
I can make it configurable via an option in case some people don't want this plugin to mess with the cursor 🤷🏾.

It's currently still WIP because I noticed whilst to screenshot it that the window closes on focus lost which is fine, but that doesn't trigger the `WinClosed` or `BufWipeout` autocommand. I'm not sure why. This only affects losing and regaining focus with the window open though, but still not a nice result.